### PR TITLE
make fetch reusable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ module.exports = (options = {}) => tree => {
       }
 
       if (node.attrs && node.attrs[options.attribute]) {
-        options.got.url = options.got.url || node.attrs[options.attribute]
+        let url = options.got.url || node.attrs[options.attribute]
 
         all.push(new Promise((resolve, reject) => {
           Promise.resolve((() => {
@@ -41,15 +41,15 @@ module.exports = (options = {}) => tree => {
           })())
             .then(responseAssign)
             .then(() => {
-              if (isUrl(options.got.url)) {
-                return got(options.got)
+              if (isUrl(url)) {
+                return got({...options.got, url: url})
               } else {
                 const response = {
                   body: undefined
                 }
 
                 try {
-                  response.body = JSON.stringify(require(path.resolve(options.got.url)))
+                  response.body = JSON.stringify(require(path.resolve(url)))
                 } catch {}
 
                 return response

--- a/test/expected/multiple-src.html
+++ b/test/expected/multiple-src.html
@@ -1,0 +1,2 @@
+Scrum
+Response from API

--- a/test/fixtures/multiple-src.html
+++ b/test/fixtures/multiple-src.html
@@ -1,0 +1,2 @@
+<fetch url="./test/fixtures/local.json">{{ response.name }}</fetch>
+<fetch url="http://www.mocky.io/v2/5e7f38562f00007200bac2ab">{{ response }}</fetch>

--- a/test/test.js
+++ b/test/test.js
@@ -90,3 +90,7 @@ test('It uses options passed to got', async t => {
 test('It works with custom attribute', async t => {
   await process(t, 'attribute', {attribute: 'from'})
 })
+
+test('It works with multiple call of fetch', async t => {
+  await process(t, 'multiple-src')
+})


### PR DESCRIPTION
Attempts to fix issue https://github.com/posthtml/posthtml-fetch/issues/43 .
I don't know how works `got` but, I try to do my best about that, but not really confident with that part of my PR.
https://github.com/posthtml/posthtml-fetch/blob/70e5cbd4db662d52b80c04fe7243d15ede52cb3f/lib/index.js#L44-L45