### PR TITLE
feat: expressions options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,17 @@
+const got = require('got')
 const path = require('path')
 const isUrl = require('is-url')
-const got = require('got')
 const posthtml = require('posthtml')
+const merge = require('lodash.merge')
 const matcher = require('posthtml-match-helper')
 const expressions = require('posthtml-expressions')
 
 module.exports = (options = {}) => tree => {
-  options.tags = options.tags || ['fetch', 'remote']
-  options.attribute = options.attribute || 'url'
   options.got = options.got || {}
+  options.attribute = options.attribute || 'url'
+  options.expressions = options.expressions || {}
   options.preserveTag = options.preserveTag || false
+  options.tags = options.tags || ['fetch', 'remote']
 
   return new Promise((resolve, reject) => {
     const all = []
@@ -60,7 +62,16 @@ module.exports = (options = {}) => tree => {
               let content = body;
 
               try {
-                plugins.push(expressions({locals: {response: JSON.parse(body)}}))
+                plugins.push(
+                  expressions(
+                    merge(
+                      options.expressions,
+                      {
+                        locals: {response: JSON.parse(body)}
+                      }
+                  ))
+                )
+
                 content = tree.render(node.content)
               } catch {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "got": "^11.8.0",
         "is-url": "^1.2.4",
+        "lodash.merge": "^4.6.2",
         "posthtml": "^0.16.4",
         "posthtml-expressions": "^1.6.2",
         "posthtml-match-helper": "^1.0.1"
@@ -5942,8 +5943,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -14208,8 +14208,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "got": "^11.8.0",
     "is-url": "^1.2.4",
+    "lodash.merge": "^4.6.2",
     "posthtml": "^0.16.4",
     "posthtml-expressions": "^1.6.2",
     "posthtml-match-helper": "^1.0.1"

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ posthtml()
   .process('<fetch url="https://example.test">{{ response }}</fetch>')
   .then(result => console.log(result.html))
 
-  // response body
+  // => interpolated response body
 ```
 
 The response body will be available under the `response` local variable.
@@ -114,7 +114,7 @@ posthtml()
   .process('<fetch from="https://example.test">{{ response }}</fetch>')
   .then(result => {
     console.log(result.html)
-    // => ...interpolated response from https://example.test
+    // => interpolated response body
   })
 ```
 
@@ -137,13 +137,15 @@ posthtml()
   .process('<fetch url="https://example.test">{{ response }}</fetch>')
   .then(result => {
     console.log(result.html)
-    // => ...interpolated response from https://example.test
+    // => interpolated response body
   })
 ```
 
 ### `preserveTag`
 
-Allows you to leave an item. Default value `false`.
+Default: `false`
+
+When set to `true`, this option will preserve the `tag` around the response body.
 
 Example:
 
@@ -158,7 +160,32 @@ posthtml()
   .process('<fetch url="https://example.test">{{ response }}</fetch>')
   .then(result => {
     console.log(result.html)
-    // => <fetch url="https://example.test">...interpolated response from https://example.test</fetch>
+    // => <fetch url="https://example.test">interpolated response body</fetch>
+  })
+```
+
+### `expressions`
+
+Default: `{}`
+
+You can pass options to `posthtml-expressions`.
+
+Example:
+
+```js
+const posthtml = require('posthtml')
+const pf = require('posthtml-fetch')
+
+posthtml()
+  .use(pf({
+    expressions: {
+      delimiters: ['[[', ']]'],
+    }
+  }))
+  .process('<fetch url="https://example.test">[[ response ]]</fetch>')
+  .then(result => {
+    console.log(result.html)
+    // => interpolated response body
   })
 ```
 
@@ -193,7 +220,7 @@ posthtml()
   .process('<fetch url="https://example.test">{{ response }}</fetch>')
   .then(result => {
     console.log(result.html)
-    // => ...interpolated response from https://example.test
+    // => interpolated response body
   })
 ```
 

--- a/test/expected/expressions-options.html
+++ b/test/expected/expressions-options.html
@@ -1,0 +1,1 @@
+User name: Leanne Graham

--- a/test/fixtures/expressions-options.html
+++ b/test/fixtures/expressions-options.html
@@ -1,0 +1,3 @@
+<fetch url="https://jsonplaceholder.typicode.com/users/1">
+  User name: [[ response.name ]]
+</fetch>

--- a/test/test.js
+++ b/test/test.js
@@ -94,3 +94,7 @@ test('It works with custom attribute', async t => {
 test('It works with multiple call of fetch', async t => {
   await process(t, 'multiple-src')
 })
+
+test('It works with options passed to posthtml-expressions', async t => {
+  await process(t, 'expressions-options', {expressions: {delimiters: ['[[', ']]']}})
+})


### PR DESCRIPTION
This PR adds support for passing in options for `posthtml-expressions`.

For example:

```js
const posthtml = require('posthtml')
const pf = require('posthtml-fetch')

posthtml()
  .use(pf({
    expressions: {
      delimiters: ['[[', ']]'],
    }
  }))
  .process('<fetch url="https://example.test">[[ response ]]</fetch>')
  .then(result => {
    console.log(result.html)
    // => interpolated response body
  })
```